### PR TITLE
Implement Single View Mode

### DIFF
--- a/Tatsi.podspec
+++ b/Tatsi.podspec
@@ -67,7 +67,7 @@ Pod::Spec.new do |s|
   #
 
   # s.platform     = :ios
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "10.0"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/Tatsi.xcodeproj/project.pbxproj
+++ b/Tatsi.xcodeproj/project.pbxproj
@@ -735,7 +735,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = N4KR5KV52L;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "co.awkward.tatsi-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -751,7 +751,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = N4KR5KV52L;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "co.awkward.tatsi-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -773,7 +773,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Tatsi/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.awkward.tatsi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -800,7 +800,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Tatsi/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.awkward.tatsi;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Tatsi.xcodeproj/project.pbxproj
+++ b/Tatsi.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		0C5B61951F0E3E13005A25CE /* PHAssetCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5B61941F0E3E13005A25CE /* PHAssetCollectionExtensions.swift */; };
 		0C5B61971F0E3EDD005A25CE /* CGSizeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5B61961F0E3EDD005A25CE /* CGSizeExtensions.swift */; };
 		0C5B61B31F0FC82D005A25CE /* AlbumsTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5B61B21F0FC82D005A25CE /* AlbumsTableHeaderView.swift */; };
+		0C76843A1FDEC32200514164 /* AlbumTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7684391FDEC32200514164 /* AlbumTitleView.swift */; };
+		0C7684491FDED59F00514164 /* ChangeAlbumArrowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7684481FDED59F00514164 /* ChangeAlbumArrowView.swift */; };
 		0CACBE891F13B21C00CD1B32 /* CameraIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CACBE881F13B21C00CD1B32 /* CameraIconView.swift */; };
 		0CBB28751F0FE38D00254034 /* AuthorizationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB28741F0FE38D00254034 /* AuthorizationViewController.swift */; };
 		0CBB28781F12B22D00254034 /* AssetMetadataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB28771F12B22D00254034 /* AssetMetadataView.swift */; };
@@ -117,6 +119,8 @@
 		0C5B61941F0E3E13005A25CE /* PHAssetCollectionExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PHAssetCollectionExtensions.swift; sourceTree = "<group>"; };
 		0C5B61961F0E3EDD005A25CE /* CGSizeExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGSizeExtensions.swift; sourceTree = "<group>"; };
 		0C5B61B21F0FC82D005A25CE /* AlbumsTableHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlbumsTableHeaderView.swift; sourceTree = "<group>"; };
+		0C7684391FDEC32200514164 /* AlbumTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumTitleView.swift; sourceTree = "<group>"; };
+		0C7684481FDED59F00514164 /* ChangeAlbumArrowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeAlbumArrowView.swift; sourceTree = "<group>"; };
 		0CACBE881F13B21C00CD1B32 /* CameraIconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraIconView.swift; sourceTree = "<group>"; };
 		0CBB28741F0FE38D00254034 /* AuthorizationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthorizationViewController.swift; sourceTree = "<group>"; };
 		0CBB28771F12B22D00254034 /* AssetMetadataView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetMetadataView.swift; sourceTree = "<group>"; };
@@ -268,6 +272,7 @@
 		0C5B61701F0D23BA005A25CE /* UIElements */ = {
 			isa = PBXGroup;
 			children = (
+				0C7684481FDED59F00514164 /* ChangeAlbumArrowView.swift */,
 				0C5B618A1F0E3924005A25CE /* AlbumImageView.swift */,
 				0C5B618B1F0E3924005A25CE /* SelectionIconView.swift */,
 				0C5B61B21F0FC82D005A25CE /* AlbumsTableHeaderView.swift */,
@@ -276,6 +281,7 @@
 				0CBB287F1F138B4100254034 /* LocalizableStrings.swift */,
 				0CACBE881F13B21C00CD1B32 /* CameraIconView.swift */,
 				0C19D88D1F14C3220087032A /* AlbumEmptyView.swift */,
+				0C7684391FDEC32200514164 /* AlbumTitleView.swift */,
 			);
 			path = UIElements;
 			sourceTree = "<group>";
@@ -540,12 +546,14 @@
 				0C5B61951F0E3E13005A25CE /* PHAssetCollectionExtensions.swift in Sources */,
 				0C5B618D1F0E3924005A25CE /* SelectionIconView.swift in Sources */,
 				0C5B61931F0E39A6005A25CE /* AlbumTableViewCell.swift in Sources */,
+				0C76843A1FDEC32200514164 /* AlbumTitleView.swift in Sources */,
 				0C5B61B31F0FC82D005A25CE /* AlbumsTableHeaderView.swift in Sources */,
 				0C5B617D1F0E32C0005A25CE /* TatsiConfig.swift in Sources */,
 				0C5B61911F0E39A3005A25CE /* AlbumsViewController.swift in Sources */,
 				0C5B617F1F0E3521005A25CE /* TatsiPickerViewControllerDelegate.swift in Sources */,
 				0C5B61851F0E3681005A25CE /* CameraCollectionViewCell.swift in Sources */,
 				0C5B61841F0E3681005A25CE /* AssetCollectionViewCell.swift in Sources */,
+				0C7684491FDED59F00514164 /* ChangeAlbumArrowView.swift in Sources */,
 				0CBB287E1F1389A800254034 /* TypeIcons.swift in Sources */,
 				0CACBE891F13B21C00CD1B32 /* CameraIconView.swift in Sources */,
 				0C5B618C1F0E3924005A25CE /* AlbumImageView.swift in Sources */,

--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -56,6 +56,9 @@ public struct TatsiConfig {
     /// If the picker should show empty albums. Defaults to false.
     public var showEmptyAlbums = false
     
+    /// If the picker should be a single view. This means the picker will open on the user library or a specific album. Switching can be done by tapping the on the header.
+    public var singleViewMode = false
+    
     /// The first view the picker should show to the user. Defaults to the user library.
     public var firstView = StartView.userLibrary
     

--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -96,6 +96,9 @@ public struct TatsiConfig {
             if #available(iOS 10.3, *) {
                 bannedAlbumSubtypes.append(.smartAlbumLivePhotos)
             }
+            if #available(iOS 11, *) {
+                bannedAlbumSubtypes.append(.smartAlbumAnimated)
+            }
         }
         
         return bannedAlbumSubtypes

--- a/Tatsi/Protocols/TatsiPickerViewControllerDelegate.swift
+++ b/Tatsi/Protocols/TatsiPickerViewControllerDelegate.swift
@@ -9,17 +9,48 @@
 import UIKit
 import Photos
 
+/// Defines a number of methods that will be called throughout the lifecycle of the TatsiPickerViewController. See the config for more options.
 public protocol TatsiPickerViewControllerDelegate: class {
 
+    /// Called when the user has selected assets (and tapped the done button).
+    ///
+    /// - Parameters:
+    ///   - pickerViewController: The PickerViewController that was used.
+    ///   - assets: The assets the user has selected, in the order the user has selected them.
     func pickerViewController(_ pickerViewController: TatsiPickerViewController, didPickAssets assets: [PHAsset])
     
+    /// Called when the user tapps the cancel button on the PickerViewController. By default this will dismiss the picker, but a custom implementation has to dismiss the picker.
+    ///
+    /// - Parameter pickerViewController: The PickerViewController that was used..=
     func pickerViewControllerDidCancel(_ pickerViewController: TatsiPickerViewController)
+    
+    /// Allows you to customize the text, image or tint of the UIBarButtonItem that is used as the cancel button throughout the app.
+    /// The picker will call this method when the cancel button is placed. The target, selector and accessibilityIdentifier of the returned UIBarButtonItem with be overwritten.
+    ///
+    /// - Parameter pickerViewController: The picker view controller the cancel button will be placed in.
+    /// - Returns: The cancel button that should be used inside the picker view controller.
+    func cancelBarButtonItem(for pickerViewController: TatsiPickerViewController) -> UIBarButtonItem?
+    
+    /// Allows you to customize the text, image or tint of the UIBarButtonItem that is used as the done button throughout the app.
+    /// The picker will call this method when the done button is placed. The target, selector and accessibilityIdentifier of the returned UIBarButtonItem with be overwritten.
+    ///
+    /// - Parameter pickerViewController: The picker view controller the done button will be placed in.
+    /// - Returns: The done button that should be used inside the picker view controller.
+    func doneBarButtonItem(for pickerViewController: TatsiPickerViewController) -> UIBarButtonItem?
 }
 
 extension TatsiPickerViewControllerDelegate {
     
     public func pickerViewControllerDidCancel(_ pickerViewController: TatsiPickerViewController) {
         pickerViewController.dismiss(animated: true, completion: nil)
+    }
+    
+    public func cancelBarButtonItem(for pickerViewController: TatsiPickerViewController) -> UIBarButtonItem? {
+        return nil
+    }
+    
+    public func doneBarButtonItem(for pickerViewController: TatsiPickerViewController) -> UIBarButtonItem? {
+        return nil
     }
     
 }

--- a/Tatsi/UIElements/AlbumTitleView.swift
+++ b/Tatsi/UIElements/AlbumTitleView.swift
@@ -1,0 +1,106 @@
+//
+//  AlbumTitleView.swift
+//  Tatsi
+//
+//  Created by Rens Verhoeven on 11/12/2017.
+//  Copyright © 2017 awkward. All rights reserved.
+//
+
+import UIKit
+
+/// The title view that is used in the case that "singleViewMode" is enabled. This title view will display the title of the Album, but also act as a control.
+final class AlbumTitleView: UIControl {
+
+    /// The title that should be displayed. This can be the name of the album.
+    var title: String? {
+        didSet {
+            self.titleLabel.text = self.title
+        }
+    }
+    
+    /// If the arrow should flip 180 degrees. Can be used in an animation block.
+    var flipArrow: Bool = false {
+        didSet {
+            guard self.flipArrow != oldValue else {
+                return
+            }
+            let radians: CGFloat = 180 * (CGFloat.pi / 180)
+            self.arrowIconView.transform = self.flipArrow ? CGAffineTransform(rotationAngle: radians) : .identity
+        }
+    }
+    
+    lazy fileprivate var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .black
+        label.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        label.isUserInteractionEnabled = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    lazy fileprivate var arrowIconView: ChangeAlbumArrowView = {
+        let imageView = ChangeAlbumArrowView()
+        imageView.isUserInteractionEnabled = false
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+   lazy fileprivate var directionLabel: UILabel = {
+        let label = UILabel()
+        label.text = NSLocalizedString("tasti.button.change-album", tableName: nil, bundle: Bundle.main, value: "Tap here to change", comment: "The label that is shown below the album's name to direct the user to tap the title to change the album")
+        label.textColor = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+        label.font = UIFont.systemFont(ofSize: 10)
+        label.isUserInteractionEnabled = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.setupView()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    private func setupView() {
+        self.addSubview(self.titleLabel)
+        self.addSubview(self.arrowIconView)
+        self.addSubview(self.directionLabel)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        // Note: Because this is a view that is placed inside a UINavigationBar auto layout can't be used. It can only be used when the target is iOS 11 or higher.
+        
+        let arrowIconOffset = CGPoint(x: 3, y: 2)
+        
+        var titleLabelSize = self.titleLabel.intrinsicContentSize
+        titleLabelSize.width = min(titleLabelSize.width, bounds.width)
+        var titleLabelOrigin = CGPoint()
+        
+        var arrowIconViewSize = self.arrowIconView.intrinsicContentSize
+        arrowIconViewSize.width = min(arrowIconViewSize.width, bounds.width)
+        var arrowIconViewOrigin = CGPoint()
+        
+        var directionLabelSize = self.directionLabel.intrinsicContentSize
+        directionLabelSize.width = min(directionLabelSize.width, bounds.width)
+        var directionLabelOrigin = CGPoint()
+        
+        titleLabelOrigin.x = (self.bounds.width - (titleLabelSize.width + arrowIconViewSize.width + arrowIconOffset.x)) / 2
+        arrowIconViewOrigin.x = titleLabelOrigin.x + titleLabelSize.width + arrowIconOffset.x
+        directionLabelOrigin.x = (self.bounds.width - directionLabelSize.width) / 2
+        
+        titleLabelOrigin.y = (self.bounds.height - (titleLabelSize.height + directionLabelSize.height)) / 2
+        arrowIconViewOrigin.y = titleLabelOrigin.y + ((titleLabelSize.height - arrowIconViewSize.height) / 2) + arrowIconOffset.y
+        directionLabelOrigin.y = titleLabelOrigin.y + titleLabelSize.height
+        
+        self.titleLabel.frame = CGRect(origin: titleLabelOrigin, size: titleLabelSize)
+        self.arrowIconView.frame = CGRect(origin: arrowIconViewOrigin, size: arrowIconViewSize)
+        self.directionLabel.frame = CGRect(origin: directionLabelOrigin, size: directionLabelSize)
+    }
+    
+}

--- a/Tatsi/UIElements/ChangeAlbumArrowView.swift
+++ b/Tatsi/UIElements/ChangeAlbumArrowView.swift
@@ -1,0 +1,40 @@
+//
+//  ChangeAlbumArrowView.swift
+//  Tatsi
+//
+//  Created by Rens Verhoeven on 11/12/2017.
+//  Copyright © 2017 awkward. All rights reserved.
+//
+
+import UIKit
+
+/// The arrow that is displayed in AlbumTitleView next to the title.
+internal class ChangeAlbumArrowView: UIView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .clear
+        self.isOpaque = false
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override func draw(_ rect: CGRect) {
+        let bezierPath = UIBezierPath()
+        bezierPath.move(to: CGPoint(x: 0, y: 0))
+        bezierPath.addLine(to: CGPoint(x: 5, y: 0))
+        bezierPath.addLine(to: CGPoint(x: 2.5, y: 3.5))
+        bezierPath.addLine(to: CGPoint(x: 0, y: 0))
+        bezierPath.close()
+        bezierPath.usesEvenOddFillRule = true
+        UIColor.black.setFill()
+        bezierPath.fill()
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: 5, height: 4)
+    }
+    
+}

--- a/Tatsi/Views/TatsiPickerViewController.swift
+++ b/Tatsi/Views/TatsiPickerViewController.swift
@@ -37,15 +37,21 @@ final public class TatsiPickerViewController: UINavigationController {
         case .authorized:
             //Authorized, show the album view or the album detail view.
             var album: PHAssetCollection?
+            let userLibrary = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumUserLibrary, options: nil).firstObject
             switch self.config.firstView {
             case .userLibrary:
-                 album = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumUserLibrary, options: nil).firstObject
+                 album = userLibrary
             case .album(let collection):
                 album = collection
             default:
                 break
             }
-            self.showAlbumViewController(with: album)
+            if let initialAlbum = album ?? userLibrary, self.config.singleViewMode {
+                self.viewControllers = [AssetsGridViewController(album: initialAlbum)]
+            } else {
+                self.showAlbumViewController(with: album)
+            }
+            
         case .denied, .notDetermined, .restricted:
             // Not authorized, show the view to give access
             self.viewControllers = [AuthorizationViewController()]
@@ -58,6 +64,14 @@ final public class TatsiPickerViewController: UINavigationController {
         } else {
             self.viewControllers = [AlbumsViewController()]
         }
+    }
+    
+    internal func customCancelButtonItem() -> UIBarButtonItem? {
+        return self.pickerDelegate?.cancelBarButtonItem(for: self)
+    }
+    
+    internal func customDoneButtonItem() -> UIBarButtonItem? {
+        return self.pickerDelegate?.doneBarButtonItem(for: self)
     }
 
 }


### PR DESCRIPTION
This PR allows a Single View Mode to be enabled in the picker. This will remove the navigation for albums and will instead open the picker on the grid of images/videos and allows the user to change the album by tapping the albums name.