### PR TITLE
Shared albums

### DIFF
--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -56,6 +56,9 @@ public struct TatsiConfig {
     /// If the picker should show empty albums. Defaults to false.
     public var showEmptyAlbums = false
     
+    /// If the picker should display shared (iCloud) albums. Defaults to true.
+    public var showSharedAlbums = true
+    
     /// If the picker should be a single view. This means the picker will open on the user library or a specific album. Switching can be done by tapping the on the header.
     public var singleViewMode = false
     

--- a/Tatsi/UIElements/LocalizableStrings.swift
+++ b/Tatsi/UIElements/LocalizableStrings.swift
@@ -24,9 +24,14 @@ final internal class LocalizableStrings {
         return NSLocalizedString("tatsi-picker.view.albums.back-button", tableName: nil, bundle: self.bundle, value: "Albums", comment: "The title of the back button leading to the albums view")
     }
     
-    /// The title of the header on the albums view
+    /// The title of the user albums header on the albums view
     static var albumsViewMyAlbumsHeader: String {
-        return NSLocalizedString("tatsi-picker.view.albums.my-albums.header", tableName: nil, bundle: self.bundle, value: "My Albums", comment: "The title of the header on the albums view")
+        return NSLocalizedString("tatsi-picker.view.albums.my-albums.header", tableName: nil, bundle: self.bundle, value: "My Albums", comment: "The title of the user albums header on the albums view")
+    }
+    
+    /// The title of the (iCloud) shared albums header on the albums view
+    static var albumsViewSharedAlbumsHeader: String {
+        return NSLocalizedString("tatsi-picker.view.albums.shared-albums.header", tableName: nil, bundle: self.bundle, value: "Shared Albums", comment: "The title of the (iCloud) shared albums header on the albums view")
     }
     
     /// The title for the message when the picker has no access to photos

--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -134,9 +134,11 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
             newCategories.append(AlbumCategory(headerTitle: LocalizableStrings.albumsViewMyAlbumsHeader, albums: userAlbums))
         }
         
-        let sharedAlbums = self.fetchSharedAlbums()
-        if !sharedAlbums.isEmpty {
-            newCategories.append(AlbumCategory(headerTitle: LocalizableStrings.albumsViewSharedAlbumsHeader, albums: sharedAlbums))
+        if self.config?.showSharedAlbums == true {
+            let sharedAlbums = self.fetchSharedAlbums()
+            if !sharedAlbums.isEmpty {
+                newCategories.append(AlbumCategory(headerTitle: LocalizableStrings.albumsViewSharedAlbumsHeader, albums: sharedAlbums))
+            }
         }
         self.categories = newCategories
     }


### PR DESCRIPTION
Adds support for displaying shared (iCloud) albums in the list of albums. This is enabled by default but can be disabled by setting `showSharedAlbums` in the TatsiConfig.