### PR TITLE
More color customization

### DIFF
--- a/Example/Views/Base.lproj/Main.storyboard
+++ b/Example/Views/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,27 +22,34 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="50u-FM-ddp">
-                                <rect key="frame" x="80" y="278.5" width="215" height="110"/>
+                                <rect key="frame" x="51.5" y="258.5" width="272" height="150"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zZH-ey-tdq">
-                                        <rect key="frame" x="0.0" y="0.0" width="215" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="272" height="30"/>
                                         <state key="normal" title="Show UIKit Picker"/>
                                         <connections>
                                             <action selector="showUIKitPicker:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CKm-Vt-U9t"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8PS-rH-el7">
-                                        <rect key="frame" x="0.0" y="40" width="215" height="30"/>
+                                        <rect key="frame" x="0.0" y="40" width="272" height="30"/>
                                         <state key="normal" title="Show Tatsi Picker"/>
                                         <connections>
                                             <action selector="showTatsiPicker:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ReA-El-bFN"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e4F-pv-cIX">
-                                        <rect key="frame" x="0.0" y="80" width="215" height="30"/>
+                                        <rect key="frame" x="0.0" y="80" width="272" height="30"/>
                                         <state key="normal" title="Show Tatsi Picker (Single View)"/>
                                         <connections>
                                             <action selector="showSingleViewTatsiPicker:" destination="BYZ-38-t0r" eventType="touchUpInside" id="OKE-KL-ZPV"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mQu-1N-wHw">
+                                        <rect key="frame" x="0.0" y="120" width="272" height="30"/>
+                                        <state key="normal" title="Show Tatsi Picker (Single View) - (Dark)"/>
+                                        <connections>
+                                            <action selector="showSingleViewTatsiPickerDark:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WMW-l5-3Nd"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/Example/Views/ViewController.swift
+++ b/Example/Views/ViewController.swift
@@ -61,6 +61,8 @@ final class ViewController: UIViewController {
         
         config.tableViewSelectionColor = UIColor.darkGray
         
+        config.selectionIconColor = UIColor.purple
+        
         let pickerViewController = TatsiPickerViewController(config: config)
         pickerViewController.pickerDelegate = self
         self.present(pickerViewController, animated: true, completion: nil)

--- a/Example/Views/ViewController.swift
+++ b/Example/Views/ViewController.swift
@@ -52,9 +52,12 @@ final class ViewController: UIViewController {
         config.navigationBarIsTranslucent = false
         config.navigationBarBarColor = .black
         config.navigationBarTintColor = .white
-        config.navigationBarTitleTintColor = .yellow
-        config.navigationBarSubTitleTintColor = .orange
+        config.navigationBarTitleTintColor = .white
+        config.navigationBarSubTitleTintColor = .lightGray
         
+        config.viewBackgroundColor = .black
+        config.viewTitleColor = .white
+        config.viewSubTitleColor = UIColor.lightGray
         
         
         let pickerViewController = TatsiPickerViewController(config: config)

--- a/Example/Views/ViewController.swift
+++ b/Example/Views/ViewController.swift
@@ -59,6 +59,7 @@ final class ViewController: UIViewController {
         config.viewTitleColor = .white
         config.viewSubTitleColor = UIColor.lightGray
         
+        config.tableViewSelectionColor = UIColor.darkGray
         
         let pickerViewController = TatsiPickerViewController(config: config)
         pickerViewController.pickerDelegate = self

--- a/Example/Views/ViewController.swift
+++ b/Example/Views/ViewController.swift
@@ -42,6 +42,26 @@ final class ViewController: UIViewController {
         self.present(pickerViewController, animated: true, completion: nil)
     }
 
+    @IBAction func showSingleViewTatsiPickerDark(_ sender: Any) {
+        var config = TatsiConfig.default
+        config.singleViewMode = true
+        config.showCameraOption = true
+        config.supportedMediaTypes = [.video, .image]
+        config.firstView = .userLibrary
+
+        config.navigationBarIsTranslucent = false
+        config.navigationBarBarColor = .black
+        config.navigationBarTintColor = .white
+        config.navigationBarTitleTintColor = .yellow
+        config.navigationBarSubTitleTintColor = .orange
+        
+        
+        
+        let pickerViewController = TatsiPickerViewController(config: config)
+        pickerViewController.pickerDelegate = self
+        self.present(pickerViewController, animated: true, completion: nil)
+
+    }
 }
 
 extension ViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {

--- a/Tatsi.xcodeproj/project.pbxproj
+++ b/Tatsi.xcodeproj/project.pbxproj
@@ -662,6 +662,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -712,6 +713,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Tatsi.xcodeproj/project.pbxproj
+++ b/Tatsi.xcodeproj/project.pbxproj
@@ -428,13 +428,13 @@
 					0C5B61421F0D2293005A25CE = {
 						CreatedOnToolsVersion = 8.3.2;
 						DevelopmentTeam = N4KR5KV52L;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					0C5B615C1F0D231D005A25CE = {
 						CreatedOnToolsVersion = 8.3.2;
 						DevelopmentTeam = N4KR5KV52L;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -444,6 +444,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -727,7 +728,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "co.awkward.tatsi-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -742,7 +743,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "co.awkward.tatsi-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -765,7 +766,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -790,7 +791,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.awkward.tatsi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Tatsi.xcodeproj/project.pbxproj
+++ b/Tatsi.xcodeproj/project.pbxproj
@@ -441,10 +441,9 @@
 			};
 			buildConfigurationList = 0C5B613E1F0D2293005A25CE /* Build configuration list for PBXProject "Tatsi" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -87,6 +87,14 @@ public struct TatsiConfig {
     /// NavigationBar - SubTitle tint color
     public var navigationBarSubTitleTintColor = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
     
+    /// General view backgroundcolor
+    public var viewBackgroundColor = UIColor.white
+    /// General text color
+    public var viewTitleColor: UIColor? = nil
+    /// General subtext color
+    public var viewSubTitleColor: UIColor = UIColor.gray
+    
+    
     // MARK: - Internal features
     
     /// All the PHAssetCollectionSubtypes that should not be shown to the user. Based on the current config

--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -97,6 +97,8 @@ public struct TatsiConfig {
     /// Table selection color (instead of gray/blue)
     public var tableViewSelectionColor: UIColor? = nil
     
+    /// Grid selection icon color, when people overwrite UIButton.appearance, this can mess up the selection icon color
+    public var selectionIconColor: UIColor? = nil
     
     // MARK: - Internal features
     

--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -94,6 +94,9 @@ public struct TatsiConfig {
     /// General subtext color
     public var viewSubTitleColor: UIColor = UIColor.gray
     
+    /// Table selection color (instead of gray/blue)
+    public var tableViewSelectionColor: UIColor? = nil
+    
     
     // MARK: - Internal features
     

--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -74,6 +74,19 @@ public struct TatsiConfig {
     /// If the delegate should finish immediately when maxNumberOfSelections is set to 1 and the user selects a photo
     public var finishImmediatelyWithMaximumOfOne = true
     
+    // MARK: - Colors
+    
+    /// NavigationBar - isTranslucent
+    public var navigationBarIsTranslucent = true
+    /// NavigationBar - bar color
+    public var navigationBarBarColor: UIColor? = nil
+    /// NavigationBar - tint color
+    public var navigationBarTintColor: UIColor? = nil
+    /// NavigationBar - Title tint color
+    public var navigationBarTitleTintColor = UIColor.black
+    /// NavigationBar - SubTitle tint color
+    public var navigationBarSubTitleTintColor = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+    
     // MARK: - Internal features
     
     /// All the PHAssetCollectionSubtypes that should not be shown to the user. Based on the current config

--- a/Tatsi/UIElements/AlbumTitleView.swift
+++ b/Tatsi/UIElements/AlbumTitleView.swift
@@ -18,6 +18,8 @@ final class AlbumTitleView: UIControl {
             self.titleLabel.text = self.title
         }
     }
+    var titleColor = UIColor.black
+    var subTitleColor = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
     
     /// If the arrow should flip 180 degrees. Can be used in an animation block.
     var flipArrow: Bool = false {
@@ -33,7 +35,7 @@ final class AlbumTitleView: UIControl {
     
     lazy fileprivate var titleLabel: UILabel = {
         let label = UILabel()
-        label.textColor = .black
+        label.textColor = self.titleColor
         label.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         label.isUserInteractionEnabled = false
         label.isAccessibilityElement = false
@@ -42,7 +44,7 @@ final class AlbumTitleView: UIControl {
     }()
     
     lazy fileprivate var arrowIconView: ChangeAlbumArrowView = {
-        let imageView = ChangeAlbumArrowView()
+        let imageView = ChangeAlbumArrowView(arrowColor: self.titleColor)
         imageView.isUserInteractionEnabled = false
         imageView.isAccessibilityElement = false
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -52,7 +54,7 @@ final class AlbumTitleView: UIControl {
    lazy fileprivate var directionLabel: UILabel = {
         let label = UILabel()
         label.text = NSLocalizedString("tasti.button.change-album", tableName: nil, bundle: Bundle.main, value: "Tap here to change", comment: "The label that is shown below the album's name to direct the user to tap the title to change the album")
-        label.textColor = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+        label.textColor = self.subTitleColor
         label.font = UIFont.systemFont(ofSize: 10)
         label.isUserInteractionEnabled = false
         label.isAccessibilityElement = false
@@ -62,12 +64,19 @@ final class AlbumTitleView: UIControl {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
-        self.setupView()
     }
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+    }
+    
+    convenience init(titleColor: UIColor?, subTitleColor: UIColor?) {
+        self.init(frame: CGRect.zero)
+
+        self.titleColor = titleColor ?? UIColor.black
+        self.subTitleColor = subTitleColor ?? UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+        
+        self.setupView()
     }
     
     private func setupView() {

--- a/Tatsi/UIElements/ChangeAlbumArrowView.swift
+++ b/Tatsi/UIElements/ChangeAlbumArrowView.swift
@@ -11,6 +11,8 @@ import UIKit
 /// The arrow that is displayed in AlbumTitleView next to the title.
 internal class ChangeAlbumArrowView: UIView {
     
+    var arrowColor = UIColor.black
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.backgroundColor = .clear
@@ -21,6 +23,11 @@ internal class ChangeAlbumArrowView: UIView {
         super.init(coder: aDecoder)
     }
     
+    convenience init(arrowColor: UIColor) {
+        self.init(frame: CGRect.zero)
+        self.arrowColor = arrowColor
+    }
+    
     override func draw(_ rect: CGRect) {
         let bezierPath = UIBezierPath()
         bezierPath.move(to: CGPoint(x: 0, y: 0))
@@ -29,7 +36,7 @@ internal class ChangeAlbumArrowView: UIView {
         bezierPath.addLine(to: CGPoint(x: 0, y: 0))
         bezierPath.close()
         bezierPath.usesEvenOddFillRule = true
-        UIColor.black.setFill()
+        self.arrowColor.setFill()
         bezierPath.fill()
     }
     

--- a/Tatsi/UIElements/SelectionIconView.swift
+++ b/Tatsi/UIElements/SelectionIconView.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 final internal class SelectionIconView: UIView {
+    var selectionButtonColor: UIColor? = nil
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -20,6 +21,12 @@ final internal class SelectionIconView: UIView {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+    }
+    
+    convenience init(selectionButtonColor: UIColor?) {
+        self.init(frame: CGRect.zero)
+        
+        self.selectionButtonColor = selectionButtonColor
     }
     
     override func draw(_ rect: CGRect) {
@@ -50,7 +57,12 @@ final internal class SelectionIconView: UIView {
         
         //// Fill Drawing
         let fillPath = UIBezierPath(ovalIn: CGRect(x: 1, y: 1, width: 22, height: 22))
-        self.tintColor.setFill()
+        if let color = self.selectionButtonColor {
+            color.setFill()
+        }
+        else {
+            self.tintColor.setFill()
+        }
         fillPath.fill()
         
         //// Checkmark Drawing

--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -101,7 +101,7 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
         self.tableView.rowHeight = 90
         self.tableView.separatorInset = UIEdgeInsets(top: 0, left: -10, bottom: 0, right: 0)
         self.tableView.separatorStyle = .none
-        
+        self.tableView.backgroundColor = self.config?.viewBackgroundColor
         self.tableView.accessibilityIdentifier = "tatsi.tableView.albums"
         
         self.startLoadingAlbums()
@@ -235,9 +235,12 @@ extension AlbumsViewController {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: AlbumTableViewCell.reuseIdentifier, for: indexPath) as? AlbumTableViewCell else {
             fatalError("AlbumTableViewCell probably not registered")
         }
+        cell.setupView(titleColor: self.config?.viewTitleColor, subTitleColor: self.config?.viewSubTitleColor ?? UIColor.gray)
+        
         cell.album = self.album(for: indexPath)
         cell.reloadContents(with: self.config?.assetFetchOptions())
         cell.accessoryType = (self.config?.singleViewMode ?? false) ? .none : .disclosureIndicator
+        cell.backgroundColor = self.config?.viewBackgroundColor
         return cell
     }
     

--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -56,13 +56,13 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
             PHAssetCollectionSubtype.smartAlbumScreenshots,
             PHAssetCollectionSubtype.smartAlbumAllHidden
         ]
-        if #available(iOS 10.3, *), let index = smartAlbumSortingOrder.index(of: .smartAlbumPanoramas) {
+        if #available(iOS 10.3, *), let index = smartAlbumSortingOrder.firstIndex(of: .smartAlbumPanoramas) {
             smartAlbumSortingOrder.insert(.smartAlbumLivePhotos, at: index)
         }
-        if #available(iOS 10.2, *), let index = smartAlbumSortingOrder.index(of: .smartAlbumBursts) {
+        if #available(iOS 10.2, *), let index = smartAlbumSortingOrder.firstIndex(of: .smartAlbumBursts) {
             smartAlbumSortingOrder.insert(.smartAlbumDepthEffect, at: index)
         }
-        if #available(iOS 11, *), let index = smartAlbumSortingOrder.index(of: .smartAlbumAllHidden) {
+        if #available(iOS 11, *), let index = smartAlbumSortingOrder.firstIndex(of: .smartAlbumAllHidden) {
             smartAlbumSortingOrder.insert(.smartAlbumAnimated, at: index)
         }
         return smartAlbumSortingOrder
@@ -153,7 +153,7 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
             collections.append(collection)
         })
         collections.sort { (collection1, collection2) -> Bool in
-            guard let index1 = self.smartAlbumSortingOrder.index(of: collection1.assetCollectionSubtype), let index2 = self.smartAlbumSortingOrder.index(of: collection2.assetCollectionSubtype) else {
+            guard let index1 = self.smartAlbumSortingOrder.firstIndex(of: collection1.assetCollectionSubtype), let index2 = self.smartAlbumSortingOrder.firstIndex(of: collection2.assetCollectionSubtype) else {
                 return true
             }
             return index1 < index2

--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -77,6 +77,7 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
         cancelButtonItem.target = self
         cancelButtonItem.action = #selector(cancel(_:))
         cancelButtonItem.accessibilityIdentifier = "tatsi.button.cancel"
+        cancelButtonItem.tintColor = config?.navigationBarTintColor
         self.navigationItem.rightBarButtonItem = cancelButtonItem
         
         let backButtonItem = UIBarButtonItem(title: LocalizableStrings.albumsViewBackButton, style: .plain, target: nil, action: nil)

--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -241,6 +241,13 @@ extension AlbumsViewController {
         cell.reloadContents(with: self.config?.assetFetchOptions())
         cell.accessoryType = (self.config?.singleViewMode ?? false) ? .none : .disclosureIndicator
         cell.backgroundColor = self.config?.viewBackgroundColor
+        
+        // Custom color for selection
+        if let color = self.config?.tableViewSelectionColor {
+            let selectionColorView = UIView()
+            selectionColorView.backgroundColor = color
+            cell.selectedBackgroundView = selectionColorView
+        }
         return cell
     }
     

--- a/Tatsi/Views/Albums/Cells/AlbumTableViewCell.swift
+++ b/Tatsi/Views/Albums/Cells/AlbumTableViewCell.swift
@@ -11,6 +11,9 @@ import Photos
 
 final internal class AlbumTableViewCell: UITableViewCell {
     
+    var titleColor: UIColor? = nil
+    var subTitleColor: UIColor? = nil
+
     fileprivate static let numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.usesGroupingSeparator = true
@@ -31,6 +34,7 @@ final internal class AlbumTableViewCell: UITableViewCell {
     lazy private var titleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.subheadline)
+        label.textColor = self.titleColor
         label.lineBreakMode = .byTruncatingTail
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -39,7 +43,7 @@ final internal class AlbumTableViewCell: UITableViewCell {
     lazy private  var countLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.subheadline)
-        label.textColor = UIColor.gray
+        label.textColor = self.subTitleColor
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -63,14 +67,17 @@ final internal class AlbumTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        self.setupView()
+//        self.setupView()
     }
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setupView() {
+    func setupView(titleColor: UIColor?, subTitleColor: UIColor?) {
+        self.titleColor = titleColor
+        self.subTitleColor = subTitleColor ?? UIColor.gray
+        
         self.contentView.addSubview(self.albumImageView)
         self.contentView.addSubview(self.labelsStackView)
         

--- a/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
+++ b/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
@@ -122,7 +122,7 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
         self.collectionView?.register(AssetCollectionViewCell.self, forCellWithReuseIdentifier: AssetCollectionViewCell.reuseIdentifier)
         self.collectionView?.register(CameraCollectionViewCell.self, forCellWithReuseIdentifier: CameraCollectionViewCell.reuseIdentifier)
         
-        self.collectionView?.backgroundColor = .white
+        self.collectionView?.backgroundColor = self.config?.viewBackgroundColor
         
         self.collectionView?.accessibilityIdentifier = "tatsi.collectionView.photosGrid"
         

--- a/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
+++ b/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
@@ -407,6 +407,7 @@ extension AssetsGridViewController {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AssetCollectionViewCell.reuseIdentifier, for: indexPath) as? AssetCollectionViewCell else {
             fatalError("AssetCollectionViewCell should be registered")
         }
+        cell.setupView(selectionButtonColor: self.config?.selectionIconColor)
         cell.imageSize = self.thumbnailImageSize
         cell.imageManager = self.thumbnailCachingManager
         cell.asset = asset

--- a/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
+++ b/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
@@ -98,6 +98,8 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
         buttonitem.target = self
         buttonitem.action = #selector(AssetsGridViewController.done(_:))
         buttonitem.accessibilityIdentifier = "tatsi.button.done"
+        buttonitem.tintColor = config?.navigationBarTintColor
+
         return buttonitem
     }()
     
@@ -141,6 +143,7 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
         cancelButtonItem.target = self
         cancelButtonItem.action = #selector(cancel(_:))
         cancelButtonItem.accessibilityIdentifier = "tatsi.button.cancel"
+        cancelButtonItem.tintColor = config?.navigationBarTintColor
         
         self.navigationItem.leftBarButtonItem = isRootModalViewController ? cancelButtonItem : nil
     }
@@ -251,7 +254,7 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
         self.reloadDoneButtonState()
         
         if self.config?.singleViewMode ?? false {
-            let titleView = AlbumTitleView()
+            let titleView = AlbumTitleView(titleColor: self.config?.navigationBarTitleTintColor, subTitleColor: self.config?.navigationBarSubTitleTintColor)
             titleView.title = self.album.localizedTitle
             titleView.frame = CGRect(x: 0, y: 0, width: 200, height: 44)
             titleView.addTarget(self, action: #selector(changeAlbum(_:)), for: .touchUpInside)

--- a/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
+++ b/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
@@ -365,7 +365,7 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
         if !self.selectedAssets.contains(asset) {
             self.selectedAssets.append(asset)
         }
-        if let index = self.assets?.index(of: asset) {
+        if let index = self.assets?.firstIndex(of: asset) {
             let additionalIndex = self.config?.invertUserLibraryOrder == true && self.showCameraButton ? 1 : 0
             self.collectionView.selectItem(at: IndexPath(item: index + additionalIndex, section: 0), animated: false, scrollPosition: UICollectionView.ScrollPosition())
         }
@@ -447,7 +447,7 @@ extension AssetsGridViewController {
     }
     
     override func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        guard let asset = self.asset(for: indexPath), let index = self.selectedAssets.index(of: asset) else {
+        guard let asset = self.asset(for: indexPath), let index = self.selectedAssets.firstIndex(of: asset) else {
             return
         }
         self.selectedAssets.remove(at: index)

--- a/Tatsi/Views/Assets Grid/Cells/AssetCollectionViewCell.swift
+++ b/Tatsi/Views/Assets Grid/Cells/AssetCollectionViewCell.swift
@@ -11,6 +11,8 @@ import Photos
 
 final internal class AssetCollectionViewCell: UICollectionViewCell {
     
+    var selectionButtonColor: UIColor? = nil
+    
     static var reuseIdentifier: String {
         return "asset-cell"
     }
@@ -60,7 +62,7 @@ final internal class AssetCollectionViewCell: UICollectionViewCell {
         view.isHidden = true
         view.backgroundColor = UIColor.white.withAlphaComponent(0.4)
         
-        let iconView = SelectionIconView()
+        let iconView = SelectionIconView(selectionButtonColor: self.selectionButtonColor)
         iconView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(iconView)
         view.bottomAnchor.constraint(equalTo: iconView.bottomAnchor, constant: 3).isActive = true
@@ -72,14 +74,16 @@ final internal class AssetCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        self.setupView()
+//        self.setupView()
     }
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setupView() {
+    func setupView(selectionButtonColor: UIColor?) {
+        self.selectionButtonColor = selectionButtonColor
+        
         self.contentView.addSubview(self.imageView)
         self.contentView.addSubview(self.metadataView)
         self.contentView.addSubview(self.selectedOverlay)

--- a/Tatsi/Views/AuthorizationViewController.swift
+++ b/Tatsi/Views/AuthorizationViewController.swift
@@ -16,6 +16,7 @@ final internal class AuthorizationViewController: UIViewController, PickerViewCo
         label.numberOfLines = 0
         label.textAlignment = .center
         label.font = UIFont.preferredFont(forTextStyle: .title2)
+        label.textColor = self.config?.viewTitleColor
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -25,7 +26,7 @@ final internal class AuthorizationViewController: UIViewController, PickerViewCo
         label.numberOfLines = 0
         label.textAlignment = .center
         label.font = UIFont.preferredFont(forTextStyle: .body)
-        label.textColor = .gray
+        label.textColor = self.config?.viewSubTitleColor
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -51,7 +52,7 @@ final internal class AuthorizationViewController: UIViewController, PickerViewCo
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.view.backgroundColor = .white
+        self.view.backgroundColor = self.config?.viewBackgroundColor
 
         self.setupView()
     }

--- a/Tatsi/Views/TatsiPickerViewController.swift
+++ b/Tatsi/Views/TatsiPickerViewController.swift
@@ -24,6 +24,14 @@ final public class TatsiPickerViewController: UINavigationController {
         super.init(nibName: nil, bundle: nil)
         
         self.setIntialViewController()
+        
+        // Navigation bar colors
+        self.navigationBar.isTranslucent = config.navigationBarIsTranslucent
+        self.navigationBar.barTintColor = config.navigationBarBarColor
+        if let tintColor = config.navigationBarTintColor {
+            self.navigationBar.tintColor = tintColor
+            self.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: tintColor]
+        }
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/Tatsi/Views/TatsiPickerViewController.swift
+++ b/Tatsi/Views/TatsiPickerViewController.swift
@@ -55,8 +55,7 @@ final public class TatsiPickerViewController: UINavigationController {
         case .denied, .notDetermined, .restricted:
             // Not authorized, show the view to give access
             self.viewControllers = [AuthorizationViewController()]
-        @unknown default:
-            <#fatalError()#>
+        @unknown default: break
         }
     }
     

--- a/Tatsi/Views/TatsiPickerViewController.swift
+++ b/Tatsi/Views/TatsiPickerViewController.swift
@@ -55,6 +55,8 @@ final public class TatsiPickerViewController: UINavigationController {
         case .denied, .notDetermined, .restricted:
             // Not authorized, show the view to give access
             self.viewControllers = [AuthorizationViewController()]
+        @unknown default:
+            <#fatalError()#>
         }
     }
     


### PR DESCRIPTION
For a project that requires also a Dark theme I extended the library with more options to configure the colours of various elements. I also included a Dark Themed example, so you can easily see the colour configuration options.

Note: updated to Swift 5 and removed warnings