### PR TITLE
Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Tatsi",    
+    platforms: [
+      .iOS(.v10)
+    ],
+    products: [        
+        .library(name: "Tatsi", targets: ["Tatsi"]),
+    ],
+    targets: [     
+        .target(name: "Tatsi", path: "Tatsi"),
+    ]
+)

--- a/Tatsi/Extensions/PHAssetCollectionExtensions.swift
+++ b/Tatsi/Extensions/PHAssetCollectionExtensions.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Photos
 import ObjectiveC
+import UIKit
 
 extension PHAssetCollection {
     

--- a/Tatsi/Protocols/PickerViewController.swift
+++ b/Tatsi/Protocols/PickerViewController.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Photos
+import UIKit
 
 protocol PickerViewController {
     

--- a/Tatsi/UIElements/CameraIconView.swift
+++ b/Tatsi/UIElements/CameraIconView.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 final internal class CameraIconView: UIView {
     

--- a/Tatsi/UIElements/LocalizableStrings.swift
+++ b/Tatsi/UIElements/LocalizableStrings.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 final internal class LocalizableStrings {
     

--- a/Tatsi/UIElements/TypeIcons.swift
+++ b/Tatsi/UIElements/TypeIcons.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 // swiftlint:disable type_body_length function_body_length
 final internal class TypeIcons {


### PR DESCRIPTION
Fixes #27 by adding Swift Package Manager support. 

To make it work "properly" it should be releases as a next release (1.1.5) otherwise it will not work "put of the box" but users will have to specific `master` as target branch instead fixing a version.