### PR TITLE
Load localized strings from a specified file

### DIFF
--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -80,6 +80,13 @@ public struct TatsiConfig {
 
     /// The statusbar style to be used on the screens
     public var preferredStatusBarStyle: UIStatusBarStyle = .default
+    
+    /// Set a table name to load the localizable strings used in Tatsi from a specified localizable strings file.
+    public var localizableStringsTableName: String? {
+        didSet {
+            LocalizableStrings.tableName = localizableStringsTableName
+        }
+    }
 
     // MARK: - Internal features
     

--- a/Tatsi/UIElements/AlbumTitleView.swift
+++ b/Tatsi/UIElements/AlbumTitleView.swift
@@ -51,7 +51,7 @@ final class AlbumTitleView: UIControl {
     
    lazy fileprivate var directionLabel: UILabel = {
         let label = UILabel()
-        label.text = NSLocalizedString("tasti.button.change-album", tableName: nil, bundle: Bundle.main, value: "Tap here to change", comment: "The label that is shown below the album's name to direct the user to tap the title to change the album")
+        label.text = LocalizableStrings.tapToChangeAlbumTitle
         label.textColor = TatsiConfig.default.colors.secondaryLabel
         label.font = UIFont.systemFont(ofSize: 10)
         label.isUserInteractionEnabled = false

--- a/Tatsi/UIElements/LocalizableStrings.swift
+++ b/Tatsi/UIElements/LocalizableStrings.swift
@@ -15,89 +15,96 @@ final internal class LocalizableStrings {
         return Bundle.main
     }
     
+    static var tableName: String?
+    
     /// The title at the top of the albums view
     static var albumsViewTitle: String {
-        return NSLocalizedString("tatsi-picker.view.albums.title", tableName: nil, bundle: self.bundle, value: "Photos", comment: "The title at the top of the albums view")
+        return NSLocalizedString("tatsi-picker.view.albums.title", tableName: self.tableName, bundle: self.bundle, value: "Photos", comment: "The title at the top of the albums view")
     }
     
     /// The title of the back button leading to the albums view
     static var albumsViewBackButton: String {
-        return NSLocalizedString("tatsi-picker.view.albums.back-button", tableName: nil, bundle: self.bundle, value: "Albums", comment: "The title of the back button leading to the albums view")
+        return NSLocalizedString("tatsi-picker.view.albums.back-button", tableName: self.tableName, bundle: self.bundle, value: "Albums", comment: "The title of the back button leading to the albums view")
+    }
+    
+    /// The title of the hint label below the albums's name
+    static var tapToChangeAlbumTitle: String {
+        return NSLocalizedString("tasti.button.change-album", tableName: self.tableName, bundle: self.bundle, value: "Tap here to change", comment: "The label that is shown below the album's name to direct the user to tap the title to change the album")
     }
     
     /// The title of the user albums header on the albums view
     static var albumsViewMyAlbumsHeader: String {
-        return NSLocalizedString("tatsi-picker.view.albums.my-albums.header", tableName: nil, bundle: self.bundle, value: "My Albums", comment: "The title of the user albums header on the albums view")
+        return NSLocalizedString("tatsi-picker.view.albums.my-albums.header", tableName: self.tableName, bundle: self.bundle, value: "My Albums", comment: "The title of the user albums header on the albums view")
     }
     
     /// The title of the (iCloud) shared albums header on the albums view
     static var albumsViewSharedAlbumsHeader: String {
-        return NSLocalizedString("tatsi-picker.view.albums.shared-albums.header", tableName: nil, bundle: self.bundle, value: "Shared Albums", comment: "The title of the (iCloud) shared albums header on the albums view")
+        return NSLocalizedString("tatsi-picker.view.albums.shared-albums.header", tableName: self.tableName, bundle: self.bundle, value: "Shared Albums", comment: "The title of the (iCloud) shared albums header on the albums view")
     }
     
     /// The title for the message when the picker has no access to photos
     static var authorizationViewNoAccessTitle: String {
-        return NSLocalizedString("tatsi-picker.view.authorization.no-access.title", tableName: nil, bundle: self.bundle, value: "Access Denied", comment: "The title for the message when the picker has no access to photos")
+        return NSLocalizedString("tatsi-picker.view.authorization.no-access.title", tableName: self.tableName, bundle: self.bundle, value: "Access Denied", comment: "The title for the message when the picker has no access to photos")
     }
     
     /// The message when the picker has no access to photo
     static var authorizationViewNoAccessMessage: String {
-        return NSLocalizedString("tatsi-picker.view.authorization.no-access.message", tableName: nil, bundle: self.bundle, value: "Please allow access to photos in the Settings app", comment: "The message when the picker has no access to photos")
+        return NSLocalizedString("tatsi-picker.view.authorization.no-access.message", tableName: self.tableName, bundle: self.bundle, value: "Please allow access to photos in the Settings app", comment: "The message when the picker has no access to photos")
     }
     
     /// The button on the no access view that leads to the settings in the Settings.app
     static var authorizationViewSettingsButton: String {
-        return NSLocalizedString("tatsi-picker.view.authorization.button.settings", tableName: nil, bundle: self.bundle, value: "Open Settings", comment: "The button on the no access view that leads to the settings in the Settings.app")
+        return NSLocalizedString("tatsi-picker.view.authorization.button.settings", tableName: self.tableName, bundle: self.bundle, value: "Open Settings", comment: "The button on the no access view that leads to the settings in the Settings.app")
     }
     
     /// The title for the message when the picker is requesting access to photos
     static var authorizationViewRequestingAccessTitle: String {
-        return NSLocalizedString("tatsi-picker.view.authorization.requesting-access.title", tableName: nil, bundle: self.bundle, value: "Requesting Access", comment: "The title for the message when the picker is requesting access to photos")
+        return NSLocalizedString("tatsi-picker.view.authorization.requesting-access.title", tableName: self.tableName, bundle: self.bundle, value: "Requesting Access", comment: "The title for the message when the picker is requesting access to photos")
     }
     
     /// The message when the picker is requesting access to photos
     static var authorizationViewRequestingAccessMessage: String {
-        return NSLocalizedString("tatsi-picker.view.authorization.requesting-access.message", tableName: nil, bundle: self.bundle, value: "Tap allow to give access to your photos library", comment: "The message when the picker is requesting access to photos")
+        return NSLocalizedString("tatsi-picker.view.authorization.requesting-access.message", tableName: self.tableName, bundle: self.bundle, value: "Tap allow to give access to your photos library", comment: "The message when the picker is requesting access to photos")
     }
     
     /// The title of the empty state when an album is empty
     static var emptyAlbumTitle: String {
-        return NSLocalizedString("tatsi-picker.view.album.empty.title", tableName: nil, bundle: self.bundle, value: "No Photos or Videos", comment: "The title of the empty state when an album is empty")
+        return NSLocalizedString("tatsi-picker.view.album.empty.title", tableName: self.tableName, bundle: self.bundle, value: "No Photos or Videos", comment: "The title of the empty state when an album is empty")
     }
     
     /// The message of the empty state when an album is empty
     static var emptyAlbumMessage: String {
-        return NSLocalizedString("tatsi-picker.view.album.empty.message", tableName: nil, bundle: self.bundle, value: "Save some photos or videos to your device", comment: "The message of the empty state when an album is empty")
+        return NSLocalizedString("tatsi-picker.view.album.empty.message", tableName: self.tableName, bundle: self.bundle, value: "Save some photos or videos to your device", comment: "The message of the empty state when an album is empty")
     }
     
     /// The title of the empty state when the album is loading it's assets
     static var albumLoading: String {
-        return NSLocalizedString("tatsi-picker.view.album.loading.title", tableName: nil, bundle: self.bundle, value: "Loading...", comment: "The title of the empty state when the album is loading it's assets.")
+        return NSLocalizedString("tatsi-picker.view.album.loading.title", tableName: self.tableName, bundle: self.bundle, value: "Loading...", comment: "The title of the empty state when the album is loading it's assets.")
     }
     
     /// The title of the camera button
     static var cameraButtonTitle: String {
-        return NSLocalizedString("tatsi-picker.button.camera.title", tableName: nil, bundle: self.bundle, value: "Camera", comment: "The title of the camera button")
+        return NSLocalizedString("tatsi-picker.button.camera.title", tableName: self.tableName, bundle: self.bundle, value: "Camera", comment: "The title of the camera button")
     }
     
     /// The message that the user is alerted of when the selection limit has been reached
     static var accessibilityAlertSelectionLimitReached: String {
-        return NSLocalizedString("tatsi-picker.accessibility.selection-limit-reached", tableName: nil, bundle: self.bundle, value: "The max number of assets has been selected", comment: "The message that the user is alerted of when the selection limit has been reached")
+        return NSLocalizedString("tatsi-picker.accessibility.selection-limit-reached", tableName: self.tableName, bundle: self.bundle, value: "The max number of assets has been selected", comment: "The message that the user is alerted of when the selection limit has been reached")
     }
     
     /// The image count in an album, for accessibility users
     static var accessibilityAlbumImagesCount: String {
-        return NSLocalizedString("tatsi-picker.accessibility.images-count", tableName: nil, bundle: self.bundle, value: "%d Images", comment: "The image count in an album, for accessibility users")
+        return NSLocalizedString("tatsi-picker.accessibility.images-count", tableName: self.tableName, bundle: self.bundle, value: "%d Images", comment: "The image count in an album, for accessibility users")
     }
     
     /// The accessibility hint the user gets on the album switcher to close/hide the album list
     static var accessibilityActivateToHideAlbumList: String {
-        return NSLocalizedString("tatsi-picker.accessibility.activate-to-hide-album-list", tableName: nil, bundle: self.bundle, value: "Activate to hide album list", comment: "The accessibility hint the user gets on the album switcher")
+        return NSLocalizedString("tatsi-picker.accessibility.activate-to-hide-album-list", tableName: self.tableName, bundle: self.bundle, value: "Activate to hide album list", comment: "The accessibility hint the user gets on the album switcher")
     }
     
     /// The accessibility hint the user gets on the album switcher to show/open the album list
     static var accessibilityActivateToShowAlbumList: String {
-        return NSLocalizedString("tatsi-picker.accessibility.activate-to-show-album-list", tableName: nil, bundle: self.bundle, value: "Activate to show album list", comment: "The accessibility hint the user gets on the album switcher")
+        return NSLocalizedString("tatsi-picker.accessibility.activate-to-show-album-list", tableName: self.tableName, bundle: self.bundle, value: "Activate to show album list", comment: "The accessibility hint the user gets on the album switcher")
     }
     
 }


### PR DESCRIPTION
This PR adds the possibility to load the localizable strings from a specified localizable strings file. Also moved a localized string from the albumTitleView to the LocalizableStrings file.

**Why**
I was starting to host the localizable strings in a third party tool. From there the keys are exported again and reused in an Android project. There it is not possible to have keys with a dash in it. Tatsi has a few keys with this character in it. Renaming the keys is not a good solution as this breaks backward compatibility for everyone using the library. Best seemed to me to specify a localizable strings file using the `tableName` parameter of the NSLocalizedString initialiser.