### PR TITLE
Keep selection

### DIFF
--- a/Example/Views/Base.lproj/Main.storyboard
+++ b/Example/Views/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -20,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="50u-FM-ddp">
-                                <rect key="frame" x="60.5" y="238" width="254" height="191"/>
+                                <rect key="frame" x="60.5" y="218" width="254" height="231"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zZH-ey-tdq">
                                         <rect key="frame" x="0.0" y="0.0" width="254" height="30"/>
@@ -50,8 +50,15 @@
                                             <action selector="showTatsiPickerWithCustomColors:" destination="BYZ-38-t0r" eventType="touchUpInside" id="69M-C4-9g4"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6qs-vy-Yvi">
+                                        <rect key="frame" x="0.0" y="160" width="254" height="30"/>
+                                        <state key="normal" title="Show Tatsi Picker Keeping Selection"/>
+                                        <connections>
+                                            <action selector="showTatsiPickerKeepingSelection:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vi5-j8-hZL"/>
+                                        </connections>
+                                    </button>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gk2-Pn-L7o">
-                                        <rect key="frame" x="0.0" y="160" width="254" height="31"/>
+                                        <rect key="frame" x="0.0" y="200" width="254" height="31"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open with last album" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eLC-7F-Mrx">
                                                 <rect key="frame" x="0.0" y="0.0" width="205" height="31"/>

--- a/Example/Views/ViewController.swift
+++ b/Example/Views/ViewController.swift
@@ -18,6 +18,8 @@ final class ViewController: UIViewController {
     // It is not recommended to PHAssetCollection in persitant storage. If you do, check if the album is still available before showing the picker.
     private var lastSelectedCollection: PHAssetCollection?
     
+    private var selectedAssets = [PHAsset]()
+    
     // If the rememberCollectioSwitch is turned on we return the last known collection, if available.
     private var firstView: TatsiConfig.StartView {
         if self.rememberCollectionSwitch.isOn, let lastCollection = self.lastSelectedCollection {
@@ -84,6 +86,22 @@ final class ViewController: UIViewController {
         pickerViewController.modalPresentationStyle = .fullScreen
         self.present(pickerViewController, animated: true, completion: nil)
     }
+    
+    @IBAction private func showTatsiPickerKeepingSelection(_ sender: Any) {
+        var config = TatsiConfig.default
+        
+        config.keepSelectionBetweenAlbums = true
+        config.preselectedAssets = self.selectedAssets
+        
+        config.showCameraOption = true
+        config.supportedMediaTypes = [.video, .image]
+        config.firstView = self.firstView
+        config.maxNumberOfSelections = 50
+        
+        let pickerViewController = TatsiPickerViewController(config: config)
+        pickerViewController.pickerDelegate = self
+        self.present(pickerViewController, animated: true, completion: nil)
+    }
 
 }
 
@@ -107,6 +125,7 @@ extension ViewController: TatsiPickerViewControllerDelegate {
     
     func pickerViewController(_ pickerViewController: TatsiPickerViewController, didPickAssets assets: [PHAsset]) {
         pickerViewController.dismiss(animated: true, completion: nil)
+        self.selectedAssets = assets
         print("Picked assets: \(assets)")
     }
 

--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -66,6 +66,9 @@ public struct TatsiConfig {
     /// If the picker should be a single view. This means the picker will open on the user library or a specific album. Switching can be done by tapping the on the header.
     public var singleViewMode = false
     
+    /// If the picker should keeps its selection while switching between albums. Defaults to false.
+    public var keepSelectionBetweenAlbums = false
+    
     /// The first view the picker should show to the user. Defaults to the user library.
     public var firstView = StartView.userLibrary
     

--- a/Tatsi/Config/TatsiConfig.swift
+++ b/Tatsi/Config/TatsiConfig.swift
@@ -90,6 +90,9 @@ public struct TatsiConfig {
             LocalizableStrings.tableName = localizableStringsTableName
         }
     }
+    
+    /// Set this to a number of PHAsset instances that were selected before the picker was opened.
+    public var preselectedAssets: [PHAsset]? = nil
 
     // MARK: - Internal features
     

--- a/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
+++ b/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
@@ -24,7 +24,9 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
             guard self.album != oldValue else {
                 return
             }
-            self.selectedAssets = []
+            if !(self.config?.keepSelectionBetweenAlbums ?? false) {
+                self.selectedAssets = []
+            }
             self.assets = []
             self.collectionView?.reloadData()
             

--- a/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
+++ b/Tatsi/Views/Assets Grid/AssetsGridViewController.swift
@@ -34,9 +34,12 @@ final internal class AssetsGridViewController: UICollectionViewController, Picke
         }
     }
     
-    internal fileprivate(set) var selectedAssets = [PHAsset]() {
-        didSet {
-            self.reloadDoneButtonState()
+    internal fileprivate(set) var selectedAssets: [PHAsset] {
+        get {
+            self.pickerViewController?.selectedAssets ?? []
+        }
+        set {
+            self.pickerViewController?.selectedAssets = newValue
         }
     }
     
@@ -464,6 +467,7 @@ extension AssetsGridViewController {
             self.present(cameraController, animated: true, completion: nil)
             collectionView.deselectItem(at: indexPath, animated: true)
         }
+        self.reloadDoneButtonState()
     }
     
     override func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
@@ -471,6 +475,7 @@ extension AssetsGridViewController {
             return
         }
         self.selectedAssets.remove(at: index)
+        self.reloadDoneButtonState()
     }
     
 }

--- a/Tatsi/Views/TatsiPickerViewController.swift
+++ b/Tatsi/Views/TatsiPickerViewController.swift
@@ -16,6 +16,9 @@ final public class TatsiPickerViewController: UINavigationController {
     public let config: TatsiConfig
     
     public weak var pickerDelegate: TatsiPickerViewControllerDelegate?
+    
+    // Contains all the selected assets the user has selected. If "keepSelectionBetweenAlbums" is turned off this array can reset when changing albums.
+    internal var selectedAssets = [PHAsset]()
 
     override public var preferredStatusBarStyle: UIStatusBarStyle {
         return self.config.preferredStatusBarStyle
@@ -29,6 +32,8 @@ final public class TatsiPickerViewController: UINavigationController {
 
         navigationBar.barTintColor = config.colors.background
         navigationBar.tintColor = config.colors.link
+        
+        self.selectedAssets = config.preselectedAssets ?? []
 
         self.setIntialViewController()
     }


### PR DESCRIPTION
Adds 2 options to TatsiConfig:
- Keep selection while switching between albums
- Supply pre-selected images when opening the picker, handy when you want to change the selection

I want to test this options first before merging into master. 
If you have code feedback, please post it here.
If you have feedback about the feature, see #44.